### PR TITLE
Loader in OCP dashboard

### DIFF
--- a/src/content/OCPDashboard/index.js
+++ b/src/content/OCPDashboard/index.js
@@ -349,7 +349,7 @@ const OCPDashboard = ({
           }`}
         >
           {loading ? (
-            <FLoading />
+            <div className="loading-indicator-wrapper"><FLoading /></div>
           ) : (
             <>
               <div className="content-switcher-wrapper">


### PR DESCRIPTION
This PR has
- fixed loader position in OCP dashboard
- fixes this [issue](https://github.com/CivicDataLab/hp-fiscal-data-explorer-frontend/issues/124)